### PR TITLE
Add catch-all to AlpineElement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,7 @@ if (window.AlpineComponents === undefined) {
 
 export interface AlpineElement extends HTMLElement {
     __x: ComponentController;
+    [key: string]: any;
 }
 
 declare global {


### PR DESCRIPTION
```html
<input type="text" x-ref="input"></input>
```
```ts
this.$refs.input.value // < typescript error because `value is not a member of AlpineElement which extends only HTMLElement and not others such as HTMLInputElement
```